### PR TITLE
chore. 스폰 직전 모든 몬스터 파괴, 몬스터 스폰로직 임시 조치

### DIFF
--- a/Assets/Resources/Prefabs/Monsters/MonsterA.prefab
+++ b/Assets/Resources/Prefabs/Monsters/MonsterA.prefab
@@ -67,12 +67,12 @@ MonoBehaviour:
   _hp: 5
   _maxHp: 5
   _attackDamage: 5
-  _attackActionRange: 0.7
-  _realAttackRange: 0.8
+  _attackActionRange: 1.3
+  _realAttackRange: 1.5
   _attackDelay: 2
   _defense: 0
   _moveSpeed: 1
-  _scanRange: 2
+  _scanRange: 5
   _minX: 0
   _maxX: 0
   _isStopOnIdle: 0

--- a/Assets/_Script/Monster/MonsterSpawnData.cs
+++ b/Assets/_Script/Monster/MonsterSpawnData.cs
@@ -35,4 +35,6 @@ public struct SpawnInfo
     public bool isStopOnTrack;
     public bool isBoss;
     public Vector2 spawnPosition;
+    public float tempMinX;
+    public float tempMaxX;
 }

--- a/Assets/_Script/Monster/MonstersManager.cs
+++ b/Assets/_Script/Monster/MonstersManager.cs
@@ -9,6 +9,8 @@ public class MonstersManager : MonoBehaviour
     // 역할1. 스테이지 이름를 받아, MonsterSpawnData에 저장된 정보대로 몬스터를 소환
     // 역할2. ...
 
+    List<GameObject> SpawnedMonsters = new List<GameObject>();
+
     // 싱글톤(외부 스크립트에서 접근 용이)
     public static MonstersManager Instance { get; private set; }
     private void Awake()
@@ -35,6 +37,9 @@ public class MonstersManager : MonoBehaviour
     // 스테이지 이름을 받아 해당 스테이지에 몬스터를 스폰
     public void SpawnMonsters(string stageName)
     {
+        // 현재 스폰되어 있는 모든 몬스터 파괴
+        DestroyAllMonsters();
+
         var spawnInfo = monsterSpawnData.GetSpawnInfoByStageName(stageName);
         if (spawnInfo != null)
         {
@@ -50,6 +55,7 @@ public class MonstersManager : MonoBehaviour
             if (monsterPrefab != null)
             {
                 GameObject monsterObj = Instantiate(monsterPrefab, spawnInfo.spawnPosition, Quaternion.identity);
+                SpawnedMonsters.Add(monsterObj);
 
                 // "Ground"와 "Passthrough" 레이어에만 있는 물체를 감지하기 위한 LayerMask 생성
                 int layerMask = LayerMask.GetMask("Ground", "Passthrough");
@@ -65,14 +71,20 @@ public class MonstersManager : MonoBehaviour
                     float maxX = hit.collider.bounds.max.x - colliderHalfWidth;
 
                     float genY = hit.collider.bounds.max.y;
-                    monsterObj.transform.position = new Vector3(monsterObj.transform.position.x, genY, monsterObj.transform.position.z);
+                    // 해결 될 때 까지 임시조치
+                    //monsterObj.transform.position = new Vector3(monsterObj.transform.position.x, genY, monsterObj.transform.position.z);
 
                     // MonsterStat MinX, MaxX 설정, bool 관련 설정
                     MonsterStat monsterStat = monsterObj.GetComponent<MonsterStat>();
                     if (monsterStat != null)
                     {
-                        monsterStat.MinX = minX;
-                        monsterStat.MaxX = maxX;
+                        //monsterStat.MinX = minX; // 해결 될 때 까지 임시조치
+                        //monsterStat.MaxX = maxX;
+
+                        // 임시조치
+                        monsterStat.MinX = spawnInfo.spawnPosition.x - spawnInfo.tempMinX;
+                        monsterStat.MaxX = spawnInfo.spawnPosition.x + spawnInfo.tempMaxX;
+
                         monsterStat.IsStopOnIdle = spawnInfo.isStopOnIdle;
                         monsterStat.IsStopOnTrack = spawnInfo.isStopOnTrack;
                     }
@@ -87,6 +99,13 @@ public class MonstersManager : MonoBehaviour
 
     private void DestroyAllMonsters()
     {
+        // 리스트에 있는 모든 몬스터 오브젝트를 파괴
+        foreach (var monster in SpawnedMonsters)
+        {
+            Destroy(monster);
+        }
 
+        // 리스트 비우기
+        SpawnedMonsters.Clear();
     }
 }


### PR DESCRIPTION
### 임시조치 (스폰 좌표의 재조정 로직이 현재 타일맵 구조에서 오작동하여 수리 필요)
MonsterSpawnData(SO)에
- Spawn Position을 정확한 위치에 지정
- TempMinX와 TempMaxX 에 좌우로 이동할 범위를 직접 지정 바람.

### 기타
스테이지 이동 시, MonstersManager.Instance.SpawnMonsters("stage1-1"); 와 같이 스테이지 이름으로 호출이 필요함.
아래 이미지의 SO에서, 스테이지 이름에 따른 스폰 몹들의 세팅을 설정 가능. 스테이지 이름만 안 겹치면 막 추가해도 상관 없으니 자유롭게 사용바람
![image](https://github.com/Hwan20173059/FindTreasure/assets/21221633/0a600496-02c9-45b7-9d67-2825cecc2ba0)
