### PR TITLE
Feat. 몬스터 스폰 시 Y축 자동조정 및 X 이동범위 자동화 가능

### DIFF
--- a/Assets/ScriptableObjects/Monsters/SpawnDatas/MonsterSpawnData.asset
+++ b/Assets/ScriptableObjects/Monsters/SpawnDatas/MonsterSpawnData.asset
@@ -20,15 +20,17 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 113.5, y: 12.1}
-      tempMinX: 2
-      tempMaxX: 2
+      autoAdjustPosition: 1
+      tempMinX: 0
+      tempMaxX: 0
     - monsterType: MonsterA
       isStopOnIdle: 0
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 127.5, y: 18.1}
-      tempMinX: 2
-      tempMaxX: 2
+      autoAdjustPosition: 1
+      tempMinX: 0
+      tempMaxX: 0
   - stageName: Stage5
     spawnInfos:
     - monsterType: MonsterA
@@ -36,6 +38,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 93, y: 24.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterC
@@ -43,6 +46,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 82, y: 24.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterC
@@ -50,6 +54,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 71, y: 24.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterA
@@ -57,6 +62,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 60, y: 24.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
   - stageName: Stage6
@@ -66,6 +72,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 35.5, y: 24.1}
+      autoAdjustPosition: 0
       tempMinX: 5
       tempMaxX: 5
     - monsterType: MonsterB
@@ -73,6 +80,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 26.5, y: 32.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterC
@@ -80,6 +88,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 26.5, y: 24.1}
+      autoAdjustPosition: 0
       tempMinX: 5
       tempMaxX: 5
     - monsterType: MonsterB
@@ -87,6 +96,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 38.5, y: 36.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterA
@@ -94,6 +104,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 32.5, y: 42.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterA
@@ -101,6 +112,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 32.5, y: 46.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterB
@@ -108,6 +120,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 26.5, y: 56.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterB
@@ -115,6 +128,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 38.5, y: 60.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
   - stageName: Stage7
@@ -124,6 +138,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 5, y: 27.1}
+      autoAdjustPosition: 0
       tempMinX: 5
       tempMaxX: 5
     - monsterType: MonsterA_Large
@@ -131,6 +146,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 0, y: 27.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterC
@@ -138,6 +154,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: -8, y: 27.1}
+      autoAdjustPosition: 0
       tempMinX: 5
       tempMaxX: 5
     - monsterType: MonsterA_Large
@@ -145,6 +162,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 7, y: 22.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterB
@@ -152,6 +170,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: -8, y: 22.1}
+      autoAdjustPosition: 0
       tempMinX: 0
       tempMaxX: 0
     - monsterType: MonsterA_Large
@@ -159,6 +178,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: -8, y: 15.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterC
@@ -166,6 +186,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 8.5, y: 15.1}
+      autoAdjustPosition: 0
       tempMinX: 3
       tempMaxX: 3
     - monsterType: MonsterC
@@ -173,6 +194,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 14.5, y: 15.1}
+      autoAdjustPosition: 0
       tempMinX: 3
       tempMaxX: 3
   - stageName: Stage8
@@ -182,6 +204,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 1.5, y: 50.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterB
@@ -189,6 +212,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: -8.5, y: 54.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterD
@@ -196,6 +220,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 6.5, y: 56.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterB
@@ -203,6 +228,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 16, y: 60.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterD
@@ -210,6 +236,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: -3, y: 62.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterD
@@ -217,6 +244,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: -7.5, y: 62.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterD
@@ -224,6 +252,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: -1, y: 36.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterD
@@ -231,6 +260,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 4.5, y: 36.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
   - stageName: Stage9
@@ -240,6 +270,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 54.5, y: 60.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterA_Large
@@ -247,6 +278,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 60, y: 60.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterD
@@ -254,6 +286,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 65.5, y: 60.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
   - stageName: Stage10
@@ -263,6 +296,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 85, y: 56.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterC
@@ -270,6 +304,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 90.5, y: 52.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterC
@@ -277,6 +312,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 95.5, y: 48.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterA_Large
@@ -284,6 +320,7 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 93.5, y: 36.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2
     - monsterType: MonsterA_Large
@@ -291,5 +328,6 @@ MonoBehaviour:
       isStopOnTrack: 0
       isBoss: 0
       spawnPosition: {x: 85, y: 36.1}
+      autoAdjustPosition: 0
       tempMinX: 2
       tempMaxX: 2

--- a/Assets/_Script/Monster/MonsterSpawnData.cs
+++ b/Assets/_Script/Monster/MonsterSpawnData.cs
@@ -35,6 +35,7 @@ public struct SpawnInfo
     public bool isStopOnTrack;
     public bool isBoss;
     public Vector2 spawnPosition;
+    public bool autoAdjustPosition;
     public float tempMinX;
     public float tempMaxX;
 }

--- a/Assets/_Script/Monster/MonstersManager.cs
+++ b/Assets/_Script/Monster/MonstersManager.cs
@@ -1,7 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using Unity.VisualScripting;
 using UnityEngine;
+using static UnityEngine.UI.Image;
 
 // 몬스터 스폰과 관리, 상태관리
 public class MonstersManager : MonoBehaviour
@@ -74,6 +76,7 @@ public class MonstersManager : MonoBehaviour
             SpawnMonstersFromList(spawnInfo.spawnInfos);
         }
     }
+
     private void SpawnMonstersFromList(List<SpawnInfo> spawnData)
     {
         foreach (var spawnInfo in spawnData)
@@ -85,44 +88,92 @@ public class MonstersManager : MonoBehaviour
                 GameObject monsterObj = Instantiate(monsterPrefab, spawnInfo.spawnPosition, Quaternion.identity);
                 SpawnedMonsters.Add(monsterObj);
 
-                // "Ground"와 "Passthrough" 레이어에만 있는 물체를 감지하기 위한 LayerMask 생성
-                int layerMask = LayerMask.GetMask("Ground", "Passthrough");
+                // 현재 몬스터 Stat의 MinX, MaxX 등을 재설정하기 위해 준비
+                MonsterStat monsterStat = monsterObj.GetComponent<MonsterStat>();
 
-                // ray 쏘기
-                RaycastHit2D hit = Physics2D.Raycast(spawnInfo.spawnPosition, Vector2.down, 10f, layerMask);
-                if (hit.collider != null)
+                // 스폰 시 Y값 및, X범위를 바로 아래 플랫폼의 모양에 따라 재할당
+                if (spawnInfo.autoAdjustPosition)
                 {
-                    // 하단 콜라이더의 경계를 기반으로 MinX와 MaxX 계산
-                    BoxCollider2D monsterCollider = monsterObj.GetComponent<BoxCollider2D>();
-                    float colliderHalfWidth = monsterCollider != null ? monsterCollider.size.x * monsterObj.transform.localScale.x / 2f : 0;
-                    float minX = hit.collider.bounds.min.x + colliderHalfWidth;
-                    float maxX = hit.collider.bounds.max.x - colliderHalfWidth;
+                    // "Ground"와 "Passthrough" 레이어에만 있는 물체를 감지하기 위한 LayerMask 생성
+                    int layerMask = LayerMask.GetMask("Ground", "Passthrough");
 
-                    float genY = hit.collider.bounds.max.y;
-                    // 해결 될 때 까지 임시조치
-                    //monsterObj.transform.position = new Vector3(monsterObj.transform.position.x, genY, monsterObj.transform.position.z);
+                    // ray 쏘기
+                    RaycastHit2D hit = Physics2D.Raycast(spawnInfo.spawnPosition, Vector2.down, Mathf.Infinity, layerMask);
 
-                    // MonsterStat MinX, MaxX 설정, bool 관련 설정
-                    MonsterStat monsterStat = monsterObj.GetComponent<MonsterStat>();
-                    if (monsterStat != null)
+                    if (hit.collider != null)
                     {
-                        //monsterStat.MinX = minX; // 해결 될 때 까지 임시조치
-                        //monsterStat.MaxX = maxX;
+                        Vector3 monsterPosition = spawnInfo.spawnPosition;
 
-                        // 임시조치
-                        monsterStat.MinX = spawnInfo.spawnPosition.x - spawnInfo.tempMinX;
-                        monsterStat.MaxX = spawnInfo.spawnPosition.x + spawnInfo.tempMaxX;
+                        // 몬스터의 Y 위치 설정
+                        monsterPosition.y = hit.point.y;
+                        monsterObj.transform.position = monsterPosition;
 
-                        monsterStat.IsStopOnIdle = spawnInfo.isStopOnIdle;
-                        monsterStat.IsStopOnTrack = spawnInfo.isStopOnTrack;
+                        // 이동 범위 설정
+                        float leftBoundary = FindBoundary(monsterObj, Vector2.left, layerMask);
+                        float rightBoundary = FindBoundary(monsterObj, Vector2.right, layerMask);
+
+                        BoxCollider2D monsterCollider = monsterObj.GetComponent<BoxCollider2D>();
+                        float colliderHalfWidth = monsterCollider != null ? monsterCollider.size.x * monsterObj.transform.localScale.x / 2f : 0;
+                        monsterStat.MinX = Mathf.Min(spawnInfo.spawnPosition.x, leftBoundary + colliderHalfWidth);
+                        monsterStat.MaxX = Mathf.Max(rightBoundary - colliderHalfWidth, spawnInfo.spawnPosition.x);
+
                     }
                 }
+                // 스폰 시 위치 및 X범위를 수동으로 할당
+                else
+                {
+                    // x 이동 범위 수동 지정
+                    monsterStat.MinX = spawnInfo.spawnPosition.x - spawnInfo.tempMinX;
+                    monsterStat.MaxX = spawnInfo.spawnPosition.x + spawnInfo.tempMaxX;
+                }
+
+                monsterStat.IsStopOnIdle = spawnInfo.isStopOnIdle;
+                monsterStat.IsStopOnTrack = spawnInfo.isStopOnTrack;
+
             }
             else
             {
-                Debug.LogError($"NotFound : MonsterPrefab {spawnInfo.monsterType} | path {prefabPath}");
+                Debug.LogError($"프리팹({spawnInfo.monsterType})을 경로({prefabPath})에서 찾을 수 없음");
             }
         }
+    }
+
+    // 몬스터의 X이동범위 자동으로 할당할 경우 탐색
+    float FindBoundary(GameObject monster, Vector2 direction, int layerMask)
+    {
+        float step = 0.05f; // Raycast를 발사할 간격
+        float maxDistance = 20f; // 최대 탐색 거리
+        float rayLength = monster.GetComponent<BoxCollider2D>().size.y; // 몬스터 콜라이더의 높이
+
+        // 몬스터 하단에서 시작
+        Vector2 basePosition = new Vector2(monster.transform.position.x, monster.transform.position.y);
+        float goalPositionX = basePosition.x;
+
+        for (float distance = 0; distance <= maxDistance; distance += step)
+        {
+            Vector2 origin = basePosition + (direction * distance);
+            Vector2 rayStartBelow = origin + new Vector2(0, 0.01f); // 아래쪽 Ray 시작점
+            Vector2 rayStartAbove = origin + new Vector2(0, 0.1f); // 위쪽 Ray 시작점
+            // 시각화 FOR DEBUG
+            //Debug.DrawRay(rayStartBelow, Vector2.down * 0.05f, Color.red, 60f);
+            //Debug.DrawRay(rayStartAbove, Vector2.up * rayLength, Color.blue, 60f);
+
+            // 아랫방향으로 짧은 Raycast 발사
+            RaycastHit2D hitBelow = Physics2D.Raycast(rayStartBelow, Vector2.down, 0.05f, layerMask);
+
+            // 몬스터 위치보다 약간 위에서 위쪽으로 Raycast 발사
+            RaycastHit2D hitAbove = Physics2D.Raycast(rayStartAbove + new Vector2(0, 0.05f), Vector2.up, rayLength, layerMask);
+
+            // 아래에는 플랫폼이 있고, 위에는 플랫폼이 없는 경우
+            if (hitBelow.collider != null && !hitAbove.collider)
+            {
+                // 이동 가능한 경계를 찾음
+                goalPositionX = basePosition.x + direction.x * distance;
+            }
+            else break;
+        }
+
+        return goalPositionX;
     }
 
     private void DestroyAllMonsters()


### PR DESCRIPTION
### 몬스터 스폰 시 Y축 자동조정 및 X 이동범위 자동화 기능 구현
- 아래의 스크린샷과 같이, SO에서 Auto Adjust Position을 선택할 경우
  - 몬스터는 기존 세팅한 Y위치 이하의 플랫폼에 안착(플랫폼에 묻힌 채로 스폰되지 않도록 스폰 위치 초기화는 필요함)
  - 안착한 플랫폼의 좌우 탐색으로 이동할 X 범위를 자동 설정
- Stage4에 시험적용


![image](https://github.com/Hwan20173059/FindTreasure/assets/21221633/62de5c5a-6f9f-473b-9bb6-3123467248cf)

![Honeycam 2024-03-04 15-23-25](https://github.com/Hwan20173059/FindTreasure/assets/21221633/97cabefc-23e2-4202-8032-525c71c7ea68)
